### PR TITLE
railshelperで使えるように画像を一括でimportしておく

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+public/bundles
+vendor
+node_modules

--- a/app/bundles/javascripts/entries/image.js
+++ b/app/bundles/javascripts/entries/image.js
@@ -1,3 +1,6 @@
-// image_bundle_tagを使いたい時はここ画像ファイルをimportしてくだい。
+// image_bundle_tagで画像を使うため一括import
 // <%= image_bundle_tag 'webpack-logo.svg' %>
-import '@image/webpack-logo.svg';
+function allRequire(context) {
+	context.keys().forEach(context);
+}
+allRequire((require).context('@image/', true, /\.*/));


### PR DESCRIPTION
https://github.com/medpeer-inc/medpacker/issues/18
の対応

## やったこと
* `@image`配下を一括でimport
* 不要ファイルをlint対象にしないよう`.eslintignore`追加しておく