### PR TITLE
remove selenium-webdriver gem from template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara'
-  gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'webdrivers'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,6 @@ DEPENDENCIES
   rack-proxy
   rails (~> 6.0.0)
   rspec-rails
-  selenium-webdriver
   spring
   spring-watcher-listen
   sqlite3

--- a/template.rb
+++ b/template.rb
@@ -62,7 +62,6 @@ end
 
 gem_group :test do
   gem 'capybara'
-  gem 'selenium-webdriver'
   gem 'webdrivers'
   gem 'rspec-rails'
   gem 'factory_bot_rails'


### PR DESCRIPTION
webdriver has dependency on selenium-webdriver.
So, selenium-webdriver is installed automatically when webdrivers gem is installed.

https://github.com/titusfortner/webdrivers/blob/master/webdrivers.gemspec#L42